### PR TITLE
fix: displays member- instead of package count

### DIFF
--- a/packages/channels-extension/src/channels/list.tsx
+++ b/packages/channels-extension/src/channels/list.tsx
@@ -131,7 +131,7 @@ const getChannelsListColumns = (): any => [
   {
     Header: '',
     accessor: 'role',
-    Cell: ({ row }: any) => formatPlural(row.original.packages_count, 'member'),
+    Cell: ({ row }: any) => formatPlural(row.original.members_count, 'member'),
     width: 20,
   },
 ];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4995967/137386202-3d3fe3c6-a5ca-4644-8ab2-39a695973085.png)
The member count was actually the number of packages in a channel.