### PR TITLE
fix: list the member count instead of the package count

### DIFF
--- a/packages/home-extension/src/index.tsx
+++ b/packages/home-extension/src/index.tsx
@@ -158,7 +158,7 @@ const getChannelsListColumns = (): any => [
   {
     Header: '',
     accessor: 'role',
-    Cell: ({ row }: any) => formatPlural(row.original.packages_count, 'member'),
+    Cell: ({ row }: any) => formatPlural(row.original.members_count, 'member'),
     width: 20,
   },
 ];


### PR DESCRIPTION
Found another place where `packages_count` is used instead of `members_count`