### PR TITLE
Fix python 3.7 syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,9 @@ jobs:
     name: Test Quetz frontend extension examples
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.10"]
 
     defaults:
       run:
@@ -68,7 +71,7 @@ jobs:
           channels:
             - https://repo.mamba.pm/conda-forge
           dependencies:
-            - python>=3.7
+            - python=${{ matrix.python-version }}
             - nodejs=16
             - yarn
           EOF

--- a/quetz_frontend/utils.py
+++ b/quetz_frontend/utils.py
@@ -45,7 +45,7 @@ def get_federated_extensions(quetzextensions_path: List[Path]) -> dict:
     """Get the metadata about federated extensions"""
 
     # Internal getter to apply lru_cache as it does not support list argument
-    @lru_cache
+    @lru_cache()
     def get_metadata(ext_dir: Path) -> list:
         datas = []
 


### PR DESCRIPTION
Remove usage of not supported `lru_cache` decorator in 3.7