### PR TITLE
Package view

### DIFF
--- a/packages/apputils/style/base.css
+++ b/packages/apputils/style/base.css
@@ -18,15 +18,11 @@
   font-size: 12px;
   background-color: #404040;
   color: #e0e0e0;
-  display: inline-block;
+  display: block;
   padding: 2px 14px;
   margin-bottom: 10px;
   border-radius: 4px;
   margin-right: 10px;
-}
-
-.tag:last-child {
-  margin-right: 0;
 }
 
 .tag.clickable {

--- a/packages/channels-extension/src/components/copy-button.tsx
+++ b/packages/channels-extension/src/components/copy-button.tsx
@@ -1,0 +1,41 @@
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+
+import { SizeProp } from '@fortawesome/fontawesome-svg-core';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import * as React from 'react';
+
+type CopyButtonProps = {
+  copyText: string;
+  size?: SizeProp;
+}
+
+/**
+ * A button to copy a text to clipboard.
+ */
+const CopyButton = (props: CopyButtonProps) => {
+
+  const [shake, setShake] = React.useState(false);
+
+  /**
+   * Animation of the icon when clicked.
+   */
+  const animate = () => {
+    setShake(true);
+    setTimeout(() => setShake(false), 1000);
+  }
+
+  return(
+    <FontAwesomeIcon className={'copy-button' + (props.size ? ` fa-${props.size}` : '') + (shake ? ' shake' : '')}
+      icon={faCopy}
+      onClick={() => {
+        animate();
+        navigator.clipboard.writeText(props.copyText);
+      }}
+    />
+  );
+
+}
+
+export default CopyButton;

--- a/packages/channels-extension/src/components/copy-button.tsx
+++ b/packages/channels-extension/src/components/copy-button.tsx
@@ -23,7 +23,7 @@ type CopyButtonProps = {
  *
  * @param props - The properties of the button, CopyButtonProps type.
  */
-const CopyButton = (props: CopyButtonProps): JSX.Element => {
+const CopyButton = (props: CopyButtonProps): React.ReactElement => {
   const [shake, setShake] = React.useState(false);
 
   /**

--- a/packages/channels-extension/src/components/copy-button.tsx
+++ b/packages/channels-extension/src/components/copy-button.tsx
@@ -7,15 +7,23 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as React from 'react';
 
 type CopyButtonProps = {
+  /**
+   * Text to copy when clicking the button.
+   */
   copyText: string;
+
+  /**
+   * Size of the icon as fontawesome SizeProp.
+   */
   size?: SizeProp;
-}
+};
 
 /**
  * A button to copy a text to clipboard.
+ *
+ * @param props - The properties of the button, CopyButtonProps type.
  */
-const CopyButton = (props: CopyButtonProps) => {
-
+const CopyButton = (props: CopyButtonProps): JSX.Element => {
   const [shake, setShake] = React.useState(false);
 
   /**
@@ -24,10 +32,15 @@ const CopyButton = (props: CopyButtonProps) => {
   const animate = () => {
     setShake(true);
     setTimeout(() => setShake(false), 1000);
-  }
+  };
 
-  return(
-    <FontAwesomeIcon className={'copy-button' + (props.size ? ` fa-${props.size}` : '') + (shake ? ' shake' : '')}
+  return (
+    <FontAwesomeIcon
+      className={
+        'copy-button' +
+        (props.size ? ` fa-${props.size}` : '') +
+        (shake ? ' shake' : '')
+      }
       icon={faCopy}
       onClick={() => {
         animate();
@@ -35,7 +48,6 @@ const CopyButton = (props: CopyButtonProps) => {
       }}
     />
   );
-
-}
+};
 
 export default CopyButton;

--- a/packages/channels-extension/src/package/tab-info.tsx
+++ b/packages/channels-extension/src/package/tab-info.tsx
@@ -11,91 +11,6 @@ import * as React from 'react';
 import PackageVersions from './versions';
 
 class PackageMainContent extends React.PureComponent<any, any> {
-  private _formatPlatform = (platforms: string[]): React.ReactNode => {
-    const linux: string[] = [];
-    const osx: string[] = [];
-    const win: string[] = [];
-    const other: string[] = [];
-
-    platforms.forEach((platform) => {
-      const os = platform.split('-')[0];
-      switch (os) {
-        case 'linux':
-          linux.push(platform);
-          break;
-        case 'osx':
-          osx.push(platform);
-          break;
-        case 'win':
-          win.push(platform);
-          break;
-        default:
-          other.push(platform);
-          break;
-      }
-    });
-
-    if (other.length === 1 && other[0] === 'noarch') {
-      return (
-        <div className="package-platform-icons">
-          <i className="fa fa-linux fa-2x package-platform-icon" />
-          <i className="fa fa-apple fa-2x package-platform-icon" />
-          <i className="fa fa-windows fa-2x package-platform-icon" />
-        </div>
-      );
-    }
-
-    return (
-      <div className="package-row-flex">
-        {linux.length !== 0 && (
-          <div>
-            <div className="package-files-row">
-              <i className="fa fa-linux fa-2x" />
-            </div>
-            <ul className="package-platform-list">
-              {linux.map((platform, index) => (
-                <p key={index}>{platform}</p>
-              ))}
-            </ul>
-          </div>
-        )}
-        {osx.length !== 0 && (
-          <div>
-            <div className="package-files-row">
-              <i className="fa fa-apple fa-2x" />
-            </div>
-            <ul className="package-platform-list">
-              {osx.map((platform, index) => (
-                <p key={index}>{platform}</p>
-              ))}
-            </ul>
-          </div>
-        )}
-        {win.length !== 0 && (
-          <div>
-            <div className="package-files-row">
-              <i className="fa fa-windows fa-2x" />
-            </div>
-            <ul className="package-platform-list">
-              {win.map((platform, index) => (
-                <p key={index}>{platform}</p>
-              ))}
-            </ul>
-          </div>
-        )}
-        {other.length !== 0 && (
-          <div>
-            <ul className="package-platform-list">
-              {other.map((platform, index) => (
-                <p key={index}>{platform}</p>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-    );
-  };
-
   render(): JSX.Element {
     const {
       match: {
@@ -129,17 +44,10 @@ class PackageMainContent extends React.PureComponent<any, any> {
               <p className="minor-paragraph">
                 {packageData.description || <i>n/a</i>}
               </p>
-              {packageData.platforms && packageData.platforms.length !== 0 && (
-                <div>
-                  <h4 className="section-heading">Platforms</h4>
-                  {this._formatPlatform(packageData.platforms)}
-                </div>
-              )}
               <PackageVersions
                 selectedPackage={packageId}
                 channel={channelId}
                 showVersionsList={true}
-                platformsList={packageData.platforms}
               />
             </>
           )}

--- a/packages/channels-extension/src/package/tab-info.tsx
+++ b/packages/channels-extension/src/package/tab-info.tsx
@@ -135,7 +135,12 @@ class PackageMainContent extends React.PureComponent<any, any> {
                   {this._formatPlatform(packageData.platforms)}
                 </div>
               )}
-              <PackageVersions selectedPackage={packageId} channel={channelId} showVersionsList={true} platformsList={packageData.platforms}/>
+              <PackageVersions
+                selectedPackage={packageId}
+                channel={channelId}
+                showVersionsList={true}
+                platformsList={packageData.platforms}
+              />
             </>
           )}
         </FetchHoc>

--- a/packages/channels-extension/src/package/tab-info.tsx
+++ b/packages/channels-extension/src/package/tab-info.tsx
@@ -135,7 +135,7 @@ class PackageMainContent extends React.PureComponent<any, any> {
                   {this._formatPlatform(packageData.platforms)}
                 </div>
               )}
-              <PackageVersions selectedPackage={packageId} channel={channelId} platformsList={packageData.platforms}/>
+              <PackageVersions selectedPackage={packageId} channel={channelId} showVersionsList={true} platformsList={packageData.platforms}/>
             </>
           )}
         </FetchHoc>

--- a/packages/channels-extension/src/package/tab-info.tsx
+++ b/packages/channels-extension/src/package/tab-info.tsx
@@ -129,16 +129,16 @@ class PackageMainContent extends React.PureComponent<any, any> {
               <p className="minor-paragraph">
                 {packageData.description || <i>n/a</i>}
               </p>
-              {packageData.platforms && packageData.platforms.lenght !== 0 && (
+              {packageData.platforms && packageData.platforms.length !== 0 && (
                 <div>
                   <h4 className="section-heading">Platforms</h4>
                   {this._formatPlatform(packageData.platforms)}
                 </div>
               )}
+              <PackageVersions selectedPackage={packageId} channel={channelId} platformsList={packageData.platforms}/>
             </>
           )}
         </FetchHoc>
-        <PackageVersions selectedPackage={packageId} channel={channelId} />
       </div>
     );
   }

--- a/packages/channels-extension/src/package/versions.tsx
+++ b/packages/channels-extension/src/package/versions.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
 type PackageVersionProps = {
   channel: string;
   selectedPackage: string;
+  platformsList?: string[];
 };
 
 type PackageVersionsState = {
@@ -24,6 +25,7 @@ class PackageVersions extends React.PureComponent<
   PackageVersionProps,
   PackageVersionsState
 > {
+
   render(): JSX.Element {
     const { channel, selectedPackage } = this.props;
     const settings = ServerConnection.makeSettings();
@@ -42,16 +44,25 @@ class PackageVersions extends React.PureComponent<
         loadingMessage={`Loading versions in ${selectedPackage}`}
         genericErrorMessage="Error fetching package versions information"
       >
-        {(versionData: any) => {
+        {(versionData: any[]) => {
           if (versionData.length === 0) {
             return <div>No versions available for the package</div>;
           }
-          // const info = versionData[0].info;
+
+          const lastVersionsData: any[] = [];
+          if (this.props.platformsList)
+            this.props.platformsList.forEach(( platform ) => {
+              lastVersionsData.push(versionData.find(version => {
+                return version["platform"] === platform;
+              }));
+            });
+          else lastVersionsData.push(versionData[0])
+
           return (
             <>
               {/*TODO: Copy button for md5 */}
               <div className="package-row-flex">
-              { versionData.map((version: any) => {
+              { lastVersionsData.map((version: any) => {
                 let info = version.info;
                 return (
                   <div>
@@ -63,7 +74,7 @@ class PackageVersions extends React.PureComponent<
                       <br />
                       <b>MD5</b>: {info.md5}
                       <br />
-                      <b>Platform</b>: {versionData[0].platform || info.platform}
+                      <b>Platform</b>: {info.platform}
                       <br />
                       <b>Version</b>: {info.version}
                     </p>

--- a/packages/channels-extension/src/package/versions.tsx
+++ b/packages/channels-extension/src/package/versions.tsx
@@ -10,9 +10,11 @@ import fromNow from 'fromnow';
 
 import * as React from 'react';
 
+import { Column } from 'react-table';
+
 import { PaginatedTable } from '@quetz-frontend/table';
 
-import CopyButton from '../components/copy-button'
+import CopyButton from '../components/copy-button';
 
 type PackageVersionProps = {
   channel: string;
@@ -30,7 +32,6 @@ class PackageVersions extends React.PureComponent<
   PackageVersionProps,
   PackageVersionsState
 > {
-
   render(): JSX.Element {
     const { channel, selectedPackage } = this.props;
     const settings = ServerConnection.makeSettings();
@@ -43,7 +44,6 @@ class PackageVersions extends React.PureComponent<
       '/versions'
     );
 
-
     return (
       <FetchHoc
         url={url}
@@ -51,53 +51,55 @@ class PackageVersions extends React.PureComponent<
         genericErrorMessage="Error fetching package versions information"
       >
         {(versionData: any) => {
-
           if (versionData.result.length === 0) {
             return <div>No versions available for the package</div>;
           }
 
           const lastVersionsData: any[] = [];
-          if (this.props.platformsList)
-            this.props.platformsList.forEach(( platform ) => {
-              lastVersionsData.push(versionData.result.find((version: { [x: string]: any; }) => {
-                return version["platform"] === platform;
-              }));
+          if (this.props.platformsList) {
+            this.props.platformsList.forEach((platform) => {
+              lastVersionsData.push(
+                versionData.result.find((version: { [x: string]: any }) => {
+                  return version['platform'] === platform;
+                })
+              );
             });
-          else lastVersionsData.push(versionData.result[0])
+          } else {
+            lastVersionsData.push(versionData.result[0]);
+          }
 
           return (
             <>
               <div className="package-row-flex">
-              { lastVersionsData.map((version: any) => {
+                {lastVersionsData.map((version: any) => {
+                  const info = version.info;
+                  return (
+                    <div key={`${info.platform}_${info.version}`}>
+                      <h4 className="section-heading">Package Info</h4>
+                      <p className="minor-paragraph">
+                        <b>Arch</b>: {info.arch || 'n/a'}
+                        <br />
+                        <b>Build</b>: {info.build || 'n/a'}
+                        <br />
+                        <b>MD5</b>: {info.md5}{' '}
+                        <CopyButton copyText={info.md5} />
+                        <br />
+                        <b>Platform</b>: {info.platform}
+                        <br />
+                        <b>Version</b>: {info.version}
+                      </p>
 
-                let info = version.info;
-                return (
-                  <div>
-                    <h4 className="section-heading">Package Info</h4>
-                    <p className="minor-paragraph">
-                      <b>Arch</b>: {info.arch || 'n/a'}
-                      <br />
-                      <b>Build</b>: {info.build || 'n/a'}
-                      <br />
-                      <b>MD5</b>: {info.md5} <CopyButton copyText={info.md5} />
-                      <br />
-                      <b>Platform</b>: {info.platform}
-                      <br />
-                      <b>Version</b>: {info.version}
-                    </p>
-
-
-                  <h4 className="section-heading">Dependencies</h4>
-                  <p className="minor-paragraph">
-                    {map(info.depends, (dep: string, key: string) => (
-                      <span key={`${info.arch}_${key}`} className="tag">
-                        {dep}
-                      </span>
-                    ))}
-                  </p>
-                </div>
-                )
-              })}
+                      <h4 className="section-heading">Dependencies</h4>
+                      <p className="minor-paragraph">
+                        {map(info.depends, (dep: string, key: string) => (
+                          <span key={`${info.arch}_${key}`} className="tag">
+                            {dep}
+                          </span>
+                        ))}
+                      </p>
+                    </div>
+                  );
+                })}
               </div>
 
               <h4 className="section-heading">Install</h4>
@@ -105,7 +107,10 @@ class PackageVersions extends React.PureComponent<
                 <pre>
                   mamba install -c {channel} {selectedPackage}
                 </pre>
-                <CopyButton copyText={`mamba install -c ${channel} ${selectedPackage}`} size='lg' />
+                <CopyButton
+                  copyText={`mamba install -c ${channel} ${selectedPackage}`}
+                  size="lg"
+                />
               </div>
 
               {this.props.showVersionsList && (
@@ -128,24 +133,22 @@ class PackageVersions extends React.PureComponent<
 
 export default PackageVersions;
 
-export const getVersionTableColumns = (baseURL: string) => [
+export const getVersionTableColumns = (
+  baseURL: string
+): ReadonlyArray<Column> => [
   {
     Header: 'Uploader',
     accessor: 'uploader.name',
-    Cell: ({ row }: any) => (row.values['uploader.name']) as any,
+    Cell: ({ row }: any) => row.values['uploader.name'] as any,
   },
   {
     Header: 'Date',
     accessor: 'time_created',
     Cell: ({ row }: any) =>
-      (
-        fromNow(
-          row.values.time_created, {
-            max: 1,
-            suffix: true,
-          }
-        )
-      )
+      fromNow(row.values.time_created, {
+        max: 1,
+        suffix: true,
+      }),
   },
   {
     Header: 'Filename',
@@ -161,38 +164,37 @@ export const getVersionTableColumns = (baseURL: string) => [
         >
           {row.values.filename}
         </a>
-      )
-    }
+      );
+    },
   },
   {
     Header: 'Platform',
     accessor: 'info.platform',
-    Cell: ({ row }: any) =>
-      {
-        const platform = row.values['info.platform'];
-        return platform === 'linux' ? (
-          <i className="fa fa-linux fa-2x" />
-        ) : platform === 'osx' ? (
-          <i className="fa fa-apple fa-2x" />
-        ) : platform === 'win' ? (
-          <i className="fa fa-windows fa-2x" />
-        ) : (
-          <div className="package-platform-noarch">
-            <i className="fa fa-linux" />
-            <i className="fa fa-apple" />
-            <i className="fa fa-windows" />
-          </div>
-        )
-      }
+    Cell: ({ row }: any) => {
+      const platform = row.values['info.platform'];
+      return platform === 'linux' ? (
+        <i className="fa fa-linux fa-2x" />
+      ) : platform === 'osx' ? (
+        <i className="fa fa-apple fa-2x" />
+      ) : platform === 'win' ? (
+        <i className="fa fa-windows fa-2x" />
+      ) : (
+        <div className="package-platform-noarch">
+          <i className="fa fa-linux" />
+          <i className="fa fa-apple" />
+          <i className="fa fa-windows" />
+        </div>
+      );
+    },
   },
   {
     Header: 'Size',
     accessor: 'info.size',
-    Cell: ({ row }: any) => (formatSize(row.values['info.size'])) as any,
+    Cell: ({ row }: any) => formatSize(row.values['info.size']) as any,
   },
   {
     Header: 'Version',
     accessor: 'version',
-    Cell: ({ row }: any) => (row.values.version) as any,
-  }
+    Cell: ({ row }: any) => row.values.version as any,
+  },
 ];

--- a/packages/channels-extension/src/package/versions.tsx
+++ b/packages/channels-extension/src/package/versions.tsx
@@ -12,6 +12,8 @@ import * as React from 'react';
 
 import { PaginatedTable } from '@quetz-frontend/table';
 
+import CopyButton from '../components/copy-button'
+
 type PackageVersionProps = {
   channel: string;
   selectedPackage: string;
@@ -65,7 +67,6 @@ class PackageVersions extends React.PureComponent<
 
           return (
             <>
-              {/*TODO: Copy button for md5 */}
               <div className="package-row-flex">
               { lastVersionsData.map((version: any) => {
 
@@ -78,7 +79,7 @@ class PackageVersions extends React.PureComponent<
                       <br />
                       <b>Build</b>: {info.build || 'n/a'}
                       <br />
-                      <b>MD5</b>: {info.md5}
+                      <b>MD5</b>: {info.md5} <CopyButton copyText={info.md5} />
                       <br />
                       <b>Platform</b>: {info.platform}
                       <br />
@@ -104,6 +105,7 @@ class PackageVersions extends React.PureComponent<
                 <pre>
                   mamba install -c {channel} {selectedPackage}
                 </pre>
+                <CopyButton copyText={`mamba install -c ${channel} ${selectedPackage}`} size='lg' />
               </div>
 
               {this.props.showVersionsList && (
@@ -120,11 +122,9 @@ class PackageVersions extends React.PureComponent<
           );
         }}
       </FetchHoc>
-
     );
   }
 }
-
 
 export default PackageVersions;
 
@@ -151,7 +151,6 @@ export const getVersionTableColumns = (baseURL: string) => [
     Header: 'Filename',
     accessor: 'filename',
     Cell: ({ row }: any) => {
-      console.log(row);
       return (
         <a
           href={URLExt.join(

--- a/packages/channels-extension/src/package/versions.tsx
+++ b/packages/channels-extension/src/package/versions.tsx
@@ -46,44 +46,49 @@ class PackageVersions extends React.PureComponent<
           if (versionData.length === 0) {
             return <div>No versions available for the package</div>;
           }
-          const info = versionData[0].info;
+          // const info = versionData[0].info;
           return (
             <>
               {/*TODO: Copy button for md5 */}
               <div className="package-row-flex">
-                <div>
-                  <h4 className="section-heading">Package Info</h4>
+              { versionData.map((version: any) => {
+                let info = version.info;
+                return (
+                  <div>
+                    <h4 className="section-heading">Package Info</h4>
+                    <p className="minor-paragraph">
+                      <b>Arch</b>: {info.arch || 'n/a'}
+                      <br />
+                      <b>Build</b>: {info.build || 'n/a'}
+                      <br />
+                      <b>MD5</b>: {info.md5}
+                      <br />
+                      <b>Platform</b>: {versionData[0].platform || info.platform}
+                      <br />
+                      <b>Version</b>: {info.version}
+                    </p>
+
+
+                  <h4 className="section-heading">Dependencies</h4>
                   <p className="minor-paragraph">
-                    <b>Arch</b>: {info.arch || 'n/a'}
-                    <br />
-                    <b>Build</b>: {info.build || 'n/a'}
-                    <br />
-                    <b>MD5</b>: {info.md5}
-                    <br />
-                    <b>Platform</b>: {versionData[0].platform || info.platform}
-                    <br />
-                    <b>Version</b>: {info.version}
+                    {map(info.depends, (dep: string, key: string) => (
+                      <span key={`${info.arch}_${key}`} className="tag">
+                        {dep}
+                      </span>
+                    ))}
                   </p>
                 </div>
-
-                <div>
-                  <h4 className="section-heading">Install</h4>
-                  <div className="package-install-command">
-                    <pre>
-                      mamba install -c {channel} {selectedPackage}
-                    </pre>
-                  </div>
-                </div>
+                )
+              })}
               </div>
 
-              <h4 className="section-heading">Dependencies</h4>
-              <p className="minor-paragraph">
-                {map(info.depends, (dep: string, key: string) => (
-                  <span key={key} className="tag">
-                    {dep}
-                  </span>
-                ))}
-              </p>
+              <h4 className="section-heading">Install</h4>
+              <div className="minor-paragraph package-install-command">
+                <pre>
+                  mamba install -c {channel} {selectedPackage}
+                </pre>
+              </div>
+
               <h4 className="section-heading">History</h4>
               <table className="table-small full-width">
                 <thead>
@@ -98,7 +103,7 @@ class PackageVersions extends React.PureComponent<
                 </thead>
                 <tbody>
                   {versionData.map((version: any) => (
-                    <tr key={version.time_created}>
+                    <tr key={`${version.info.arch}_${version.time_created}`}>
                       <td>{version.uploader.name}</td>
                       <td>
                         {fromNow(version.time_created, {

--- a/packages/channels-extension/style/channels.css
+++ b/packages/channels-extension/style/channels.css
@@ -39,3 +39,22 @@
 .member-role-column {
   width: 20%;
 }
+
+.package-install-command pre {
+  display: inline;
+}
+
+.package-install-command svg {
+  float: right;
+}
+
+.copy-button.shake {
+  animation: shake 0.5s 1;
+}
+
+@keyframes shake {
+  25% { transform: rotate(-20deg);  }
+  50% { transform: rotate(30deg); }
+  75% { transform: rotate(-10deg); }
+  100%{ transform: rotate(0deg); }
+}

--- a/packages/channels-extension/style/channels.css
+++ b/packages/channels-extension/style/channels.css
@@ -53,8 +53,16 @@
 }
 
 @keyframes shake {
-  25% { transform: rotate(-20deg);  }
-  50% { transform: rotate(30deg); }
-  75% { transform: rotate(-10deg); }
-  100%{ transform: rotate(0deg); }
+  25% {
+    transform: rotate(-20deg);
+  }
+  50% {
+    transform: rotate(30deg);
+  }
+  75% {
+    transform: rotate(-10deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
 }

--- a/packages/channels-extension/style/packages.css
+++ b/packages/channels-extension/style/packages.css
@@ -1,13 +1,22 @@
 .package-row-flex {
   display: flex;
   justify-content: space-between;
+  overflow-x: auto;
 }
 
 .package-files-row {
   display: flex;
-  padding: 18px 42px;
+  padding: 18px 5px;
   border-bottom: 1px solid var(--jp-layout-color2);
   align-items: center;
+}
+
+.platform-item {
+  margin-right: 50px;
+}
+
+.platform-item:last-child {
+  margin-right: 0px;
 }
 
 .package-platform-noarch {
@@ -27,7 +36,7 @@
 
 .package-platform-list {
   list-style: none;
-  padding-left: 15px;
+  padding-left: 5px;
 }
 
 .package-install-command {


### PR DESCRIPTION
This PR must wait for https://github.com/mamba-org/quetz/pull/556 to be merged, to be able to use the pagination API on package versions.
This PR fix a part of #45 :
- shows the latest package for each platform.
- adds pagination for package versions list. This also removes the versions list from *channel -> packages* view to not have 2 pagination in the same page.
- adds a copy button for md5 and command line.

It remains to improve the view of the platforms and latest versions, which is more subjective and may deserve its own PR.