### PR TITLE
Automated Changelog Entry for 0.4.0a0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.3.1
+## 0.4.0a0
+
+([Full Changelog](https://github.com/mamba-org/quetz-frontend/compare/v0.3.1...006cf4581e42abb124230a81e533592c358dd7be))
+
+### Enhancements made
+
+- Tos [#128](https://github.com/mamba-org/quetz-frontend/pull/128) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Add jupyter releaser [#108](https://github.com/mamba-org/quetz-frontend/pull/108) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Bump to 0.3.1 [#115](https://github.com/mamba-org/quetz-frontend/pull/115) ([@fcollonval](https://github.com/fcollonval))
+
+### Other merged PRs
+
+- Split logging into multiple plugins [#126](https://github.com/mamba-org/quetz-frontend/pull/126) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix pagination in package list [#125](https://github.com/mamba-org/quetz-frontend/pull/125) ([@brichet](https://github.com/brichet))
+- Bump terser from 4.8.0 to 4.8.1 [#124](https://github.com/mamba-org/quetz-frontend/pull/124) ([@dependabot](https://github.com/dependabot))
+- Bump moment from 2.29.2 to 2.29.4 [#123](https://github.com/mamba-org/quetz-frontend/pull/123) ([@dependabot](https://github.com/dependabot))
+- Bump parse-url from 6.0.0 to 6.0.2 [#122](https://github.com/mamba-org/quetz-frontend/pull/122) ([@dependabot](https://github.com/dependabot))
+- Add footer with links and terms of services [#120](https://github.com/mamba-org/quetz-frontend/pull/120) ([@martinRenou](https://github.com/martinRenou))
+- fix styling when logged in [#119](https://github.com/mamba-org/quetz-frontend/pull/119) ([@wolfv](https://github.com/wolfv))
+- Bump moment from 2.29.1 to 2.29.2 [#117](https://github.com/mamba-org/quetz-frontend/pull/117) ([@dependabot](https://github.com/dependabot))
+- Bump minimist from 1.2.5 to 1.2.6 [#116](https://github.com/mamba-org/quetz-frontend/pull/116) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/mamba-org/quetz-frontend/graphs/contributors?from=2022-03-31&to=2022-08-11&type=c))
+
+[@brichet](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Abrichet+updated%3A2022-03-31..2022-08-11&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Adependabot+updated%3A2022-03-31..2022-08-11&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Afcollonval+updated%3A2022-03-31..2022-08-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Ahbcarlos+updated%3A2022-03-31..2022-08-11&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3AmartinRenou+updated%3A2022-03-31..2022-08-11&type=Issues) | [@wolfv](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Awolfv+updated%3A2022-03-31..2022-08-11&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.3.1


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0a0 on main
```
Python version: 0.4.0a0
npm version: quetz-frontend: 0.1.0
npm workspace versions:
@quetz-frontend/builder: 0.4.0-alpha.0
@quetz-example/light-theme: 0.4.0-alpha.0
@quetz-frontend/examples-test: 0.4.0-alpha.0
@quetz-frontend/metapackage: 0.4.0-alpha.0
@quetz-frontend/application: 0.4.0-alpha.0
@quetz-frontend/application-extension: 0.4.0-alpha.0
@quetz-frontend/apputils: 0.4.0-alpha.0
@quetz-frontend/channels-extension: 0.4.0-alpha.0
@quetz-frontend/home-extension: 0.4.0-alpha.0
@quetz-frontend/jobs-extension: 0.4.0-alpha.0
@quetz-frontend/login-extension: 0.4.0-alpha.0
@quetz-frontend/menu: 0.4.0-alpha.0
@quetz-frontend/menu-extension: 0.4.0-alpha.0
@quetz-frontend/search-extension: 0.4.0-alpha.0
@quetz-frontend/table: 0.4.0-alpha.0
@quetz-frontend/user-extension: 0.4.0-alpha.0
@quetz-frontend/main-app: 0.4.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | mamba-org/quetz-frontend  |
| Branch  | main  |
| Version Spec | 0.4.0-alpha.0 |
| Since Last Stable | true |