### PR TITLE
Automated Changelog Entry for 0.4.0a2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0a2
+
+([Full Changelog](https://github.com/mamba-org/quetz-frontend/compare/@quetz-example/light-theme@0.4.0-alpha.1...ab869cf4c50b6c0fea0d4ba0549f815db4a81308))
+
+### Enhancements made
+
+- Package view [#129](https://github.com/mamba-org/quetz-frontend/pull/129) ([@brichet](https://github.com/brichet))
+
+### Bugs fixed
+
+- Small fixes [#142](https://github.com/mamba-org/quetz-frontend/pull/142) ([@hbcarlos](https://github.com/hbcarlos))
+- Fixes #139 [#141](https://github.com/mamba-org/quetz-frontend/pull/141) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Updates dependencies [#140](https://github.com/mamba-org/quetz-frontend/pull/140) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/mamba-org/quetz-frontend/graphs/contributors?from=2022-08-11&to=2023-03-01&type=c))
+
+[@brichet](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Abrichet+updated%3A2022-08-11..2023-03-01&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Ahbcarlos+updated%3A2022-08-11..2023-03-01&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.4.0a1
 
 ([Full Changelog](https://github.com/mamba-org/quetz-frontend/compare/v0.3.1...e2d3f97a28bb71ed6d806ed3f2a391ffc85e1360))
@@ -40,8 +65,6 @@
 ([GitHub contributors page for this release](https://github.com/mamba-org/quetz-frontend/graphs/contributors?from=2022-03-31&to=2022-08-11&type=c))
 
 [@brichet](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Abrichet+updated%3A2022-03-31..2022-08-11&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Adependabot+updated%3A2022-03-31..2022-08-11&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Afcollonval+updated%3A2022-03-31..2022-08-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Ahbcarlos+updated%3A2022-03-31..2022-08-11&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3AmartinRenou+updated%3A2022-03-31..2022-08-11&type=Issues) | [@wolfv](https://github.com/search?q=repo%3Amamba-org%2Fquetz-frontend+involves%3Awolfv+updated%3A2022-03-31..2022-08-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.4.0a0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0a2 on main
```
Python version: 0.4.0a2
npm version: quetz-frontend: 0.1.0
npm workspace versions:
@quetz-frontend/builder: 0.4.0-alpha.2
@quetz-example/light-theme: 0.4.0-alpha.2
@quetz-frontend/examples-test: 0.4.0-alpha.2
@quetz-frontend/metapackage: 0.4.0-alpha.2
@quetz-frontend/application: 0.4.0-alpha.2
@quetz-frontend/application-extension: 0.4.0-alpha.2
@quetz-frontend/apputils: 0.4.0-alpha.2
@quetz-frontend/channels-extension: 0.4.0-alpha.2
@quetz-frontend/home-extension: 0.4.0-alpha.2
@quetz-frontend/jobs-extension: 0.4.0-alpha.2
@quetz-frontend/login-extension: 0.4.0-alpha.2
@quetz-frontend/menu: 0.4.0-alpha.2
@quetz-frontend/menu-extension: 0.4.0-alpha.2
@quetz-frontend/search-extension: 0.4.0-alpha.2
@quetz-frontend/table: 0.4.0-alpha.2
@quetz-frontend/user-extension: 0.4.0-alpha.2
@quetz-frontend/main-app: 0.4.0-alpha.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/mamba-org/quetz-frontend/releases/tag/untagged-34fb80b4d434498084ea  |
| Since | @quetz-example/light-theme@0.4.0-alpha.1 |