### PR TITLE
Yarn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ First of all, clone quetz and quetz-frontend, create a conda environment using t
 # Create an environment
 mamba env create -f quetz/environment.yml
 conda activate quetz
-mamba install -c conda-forge nodejs=16 yarn=1.21
+mamba install -c conda-forge nodejs=16 yarn=1.22
 ```
 
 #### Install Quetz in dev mode

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - quetz
   - nodejs=16
-  - yarn
+  - yarn=1.22


### PR DESCRIPTION
## Docs: 
yarn 1.21 seems to be no longer available via conda or conda-forge, 1.22 is.

### Environment
pinned yearn to 1.22 to be in sync with docs. No pin installs a newer yarn version >=3.5 which does not seem to work.
