### PR TITLE
fix: don't filter out packages with dot in name

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - quetz
   - nodejs=16
   - yarn=1.22
+  - pydantic<2

--- a/quetz_frontend/backend.py
+++ b/quetz_frontend/backend.py
@@ -145,6 +145,8 @@ def index(
     user_id = auth.get_user()
     profile = dao.get_profile(user_id)
 
+    # request might also be /channels/<channel_name>/packages/<package.name>
+    # where the package name contains a "."
     if "." in resource and not ('channels/' in resource and 'packages/' in resource):
         file_name = (
             resource

--- a/quetz_frontend/backend.py
+++ b/quetz_frontend/backend.py
@@ -145,7 +145,7 @@ def index(
     user_id = auth.get_user()
     profile = dao.get_profile(user_id)
 
-    if "." in resource:
+    if "." in resource and not ('channels/' in resource and 'packages/' in resource):
         file_name = (
             resource
             if ("icons" in resource or "logos" in resource or "page-data" in resource)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.7
 install_requires =
     typer>=0.4.1
     quetz-server~=0.4
-    pydantic
+    pydantic<2
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
cc @pavelzw @jannikwibker

@pavelzw found a bug that accessing the UI with URLs like
http://our.domain.com/channels/local1/packages/package_name.with_dots
results in errors.
After a long search, we found the place responsible for this!
Not sure if this is the best fix, but it should filter out all package cases.