### PR TITLE
Fix azuread login in login-extension calling wrong api

### DIFF
--- a/packages/login-extension/src/index.ts
+++ b/packages/login-extension/src/index.ts
@@ -79,7 +79,7 @@ const azure: QuetzFrontEndPlugin<void> = {
       isEnabled: () => isEnabled,
       isVisible: () => isEnabled && mainMenu.profile === null,
       execute: () => {
-        window.location.href = '/auth/azure/login';
+        window.location.href = '/auth/azuread/login';
       },
     });
 


### PR DESCRIPTION
Fix azuread login-extension wrong api call. Endpoint is `/auth/azuread/login` not `/auth/azure/login`